### PR TITLE
Added support for the new error

### DIFF
--- a/p2p/__init__.py
+++ b/p2p/__init__.py
@@ -1064,6 +1064,8 @@ class P2P(object):
                     raise P2PSearchError(resp.url, request_log)
                 elif u"Request Timeout" in resp.content:
                     raise P2PTimeoutError(resp.url, request_log)
+                elif u'Duplicate entry' in resp.content:
+                    raise P2PUniqueConstraintViolated(resp.url, request_log)
                 data = resp.json()
                 if 'errors' in data:
                     raise P2PException(data['errors'][0], request_log)


### PR DESCRIPTION
related to https://github.com/datadesk/p2p-liveblog/issues/751 and https://jira.tribpub.com/browse/CS-782

We still have to support both old and new P2PUniqueConstraintViolated variants because they still both live on. The old syntax is on stage and new syntax is on prod.