### PR TITLE
Tests are passing

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,6 @@ Add metadata to the item so it is seen by robots and remove any noindex and nofo
 
 Add metadata to the item so it is hidden from robots using the noindex and nofollow tags. Provide the slug of the content item you'd like to update.
 
-`get_thumb_for_slug(slug, force_update=False)`
-
-Get information on how to display images associated with this slug.
-
 
 ### Topics
 

--- a/p2p/__init__.py
+++ b/p2p/__init__.py
@@ -945,40 +945,6 @@ class P2P(object):
         fancy_section['path'] = path
         return fancy_section
 
-    def get_thumb_for_slug(self, slug, force_update=False):
-        """
-        Get information on how to display images associated with this slug
-        """
-        url = "%s/photos/turbine/%s.json" % (
-            self.config['IMAGE_SERVICES_URL'],
-            slug
-        )
-
-        thumb = None
-
-        if force_update:
-            log.debug("GET: %s" % url)
-            resp = self.s.get(
-                url,
-                headers=self.http_headers(),
-                verify=False)
-            if resp.ok:
-                thumb = resp.json()
-                self.cache.save_thumb(thumb)
-        else:
-            thumb = self.cache.get_thumb(slug)
-            if not thumb:
-                log.debug("GET: %s" % url)
-                resp = self.s.get(
-                    url,
-                    headers=self.http_headers(),
-                    verify=False)
-                if resp.ok:
-                    thumb = resp.json()
-                    self.cache.save_thumb(thumb)
-
-        return thumb
-
     def get_nav(self, collection_code, domain=None):
         """
         get a simple dictionary of text and links for a navigation collection

--- a/p2p/__init__.py
+++ b/p2p/__init__.py
@@ -272,8 +272,6 @@ class P2P(object):
             for i in range(len(ret)):
                 if ret[i] is None or force_update:
                     new_item = resp.pop(0)
-                    print "ids[i], new_item['id']"
-                    print ids[i], new_item['id']
                     assert ids[i] == new_item['id']
                     if new_item['status'] == 200:
                         ret[i] = new_item['body']['content_item']

--- a/p2p/__init__.py
+++ b/p2p/__init__.py
@@ -272,6 +272,8 @@ class P2P(object):
             for i in range(len(ret)):
                 if ret[i] is None or force_update:
                     new_item = resp.pop(0)
+                    print "ids[i], new_item['id']"
+                    print ids[i], new_item['id']
                     assert ids[i] == new_item['id']
                     if new_item['status'] == 200:
                         ret[i] = new_item['body']['content_item']

--- a/p2p/tests.py
+++ b/p2p/tests.py
@@ -376,12 +376,29 @@ class TestP2P(unittest.TestCase):
             self.assertIn(k, data['items'][0].keys())
 
     def test_multi_items(self):
-        data = self.p2p.get_multi_content_items(ids=self.test_story_slugs[:2])
+        """
+        Try sending in 3 ids to get_multi_content_items and assert that it
+        returns the IDs we passed in.
+        """
+        # Grab the IDs
+        ci_ids = []
+        for slug in self.test_story_slugs[:3]:
+            ci = self.p2p.get_content_item(slug)
+            ci_ids.append(ci["id"])
+
+        # Make the call
+        data = self.p2p.get_multi_content_items(ci_ids)
+
+        # Ensure the first item has all the keys we expect
         for k in self.content_item_keys:
             self.assertIn(k, data[0].keys())
 
-    def test_many_multi_items(self):
+        # Loop through each content item and ensure the ID
+        # matches what was passed in to get_multi_content_items
+        for i, ci in enumerate(data):
+            self.assertEqual(data[i]["id"], ci_ids[i])
 
+    def test_many_multi_items(self):
         self.p2p.remove_from_collection(
             self.first_test_collection_code, self.test_story_slugs
         )
@@ -427,21 +444,6 @@ class TestP2P(unittest.TestCase):
 
         for k in ('title', 'id', 'slug'):
             self.assertIn(k, data['related_items'][0]['content_item'])
-
-    def test_image_services(self):
-        data = self.p2p.get_thumb_for_slug(self.first_test_story_slug)
-
-        self.assertEqual(
-            data, {
-                u'crops': [],
-                u'height': 1200,
-                u'id': u'turbine/chi-na-lorem-a',
-                u'namespace': u'turbine',
-                u'size': 613306,
-                u'slug': u'chi-na-lorem-a',
-                u'url': u'/img-5339c184/turbine/chi-na-lorem-a',
-                u'width': 1600
-            })
 
     def test_get_section(self):
         data = self.p2p.get_section('/local')


### PR DESCRIPTION
I removed the image services test and the method `get_thumb_for_slug `, because of these reasons:

1. You need to be logged into P2P on the front end to get to it. ([Note from the newsapps team](https://github.com/newsapps/p2p-python/commit/acd2f95f8a8d6786f0362fd9a37951d0ccd371fb#diff-6170c7947caf5641ea65fd04caa7d15bR185))
2. Even when you log in to it, I couldn't get it to work through the wrapper or through a web browser
3. I'm not using it my app and I don't think any of our apps are 