### PR TITLE
Added curl logs

### DIFF
--- a/p2p/__init__.py
+++ b/p2p/__init__.py
@@ -1128,7 +1128,6 @@ class P2P(object):
 
     @retry(P2PRetryableError)
     def delete(self, url):
-
         resp = self.s.delete(
             self.config['P2P_API_ROOT'] + url,
             headers=self.http_headers(),

--- a/p2p/__init__.py
+++ b/p2p/__init__.py
@@ -958,7 +958,7 @@ class P2P(object):
         thumb = None
 
         if force_update:
-            log.debug("GET: %s" % url)
+            log.debug("[P2P][GET] %s" % url)
             resp = self.s.get(
                 url,
                 headers=self.http_headers(),
@@ -969,7 +969,7 @@ class P2P(object):
         else:
             thumb = self.cache.get_thumb(slug)
             if not thumb:
-                log.debug("GET: %s" % url)
+                log.debug("[P2P][GET] %s" % url)
                 resp = self.s.get(
                     url,
                     headers=self.http_headers(),
@@ -1057,8 +1057,7 @@ class P2P(object):
         }
 
         if self.debug:
-            for k, v in request_log.items():
-                log.debug('%s: %s' % (k, v))
+            log.debug("[P2P][RESPONSE] %s" % resp_log)
 
         if resp.status_code >= 500:
             try:
@@ -1111,10 +1110,14 @@ class P2P(object):
         resp = self.s.get(
             self.config['P2P_API_ROOT'] + url,
             headers=self.http_headers(if_modified_since=if_modified_since),
-            verify=False)
+            verify=True)
 
-        # Log the curl
-        log.debug("[P2P][GET] %s" % utils.request_to_curl(resp.request))
+        # Log the request curl if debug is on
+        if self.debug:
+            log.debug("[P2P][GET] %s" % utils.request_to_curl(resp.request))
+        # If debug is off, store a light weight log
+        else:
+            log.debug("[P2P][GET] %s" % url)
 
         resp_log = self._check_for_errors(resp)
         try:
@@ -1131,10 +1134,14 @@ class P2P(object):
         resp = self.s.delete(
             self.config['P2P_API_ROOT'] + url,
             headers=self.http_headers(),
-            verify=False)
+            verify=True)
 
-        # Log the curl
-        log.debug("[P2P][DELETE] %s" % utils.request_to_curl(resp.request))
+        # Log the request curl if debug is on
+        if self.debug:
+            log.debug("[P2P][DELETE] %s" % utils.request_to_curl(resp.request))
+        # If debug is off, store a light weight log
+        else:
+            log.debug("[P2P][DELETE] %s" % url)
 
         self._check_for_errors(resp)
         return utils.parse_response(resp.content)
@@ -1146,11 +1153,15 @@ class P2P(object):
             self.config['P2P_API_ROOT'] + url,
             data=payload,
             headers=self.http_headers('application/json'),
-            verify=False
+            verify=True
         )
 
-        # Log the curl
-        log.debug("[P2P][POST] %s" % utils.request_to_curl(resp.request))
+        # Log the request curl if debug is on
+        if self.debug:
+            log.debug("[P2P][POST] %s" % utils.request_to_curl(resp.request))
+        # If debug is off, store a light weight log
+        else:
+            log.debug("[P2P][POST] %s" % url)
 
         resp_log = self._check_for_errors(resp)
 
@@ -1170,11 +1181,15 @@ class P2P(object):
             self.config['P2P_API_ROOT'] + url,
             data=payload,
             headers=self.http_headers('application/json'),
-            verify=False
+            verify=True
         )
 
-        # Log the curl
-        log.debug("[P2P][PUT] %s" % utils.request_to_curl(resp.request))
+        # Log the request curl if debug is on
+        if self.debug:
+            log.debug("[P2P][PUT] %s" % utils.request_to_curl(resp.request))
+        # If debug is off, store a light weight log
+        else:
+            log.debug("[P2P][PUT] %s" % url)
 
         resp_log = self._check_for_errors(resp)
 

--- a/p2p/utils.py
+++ b/p2p/utils.py
@@ -114,3 +114,27 @@ def parsedate(d):
         return iso8601.parse_date(d).replace(tzinfo=pytz.utc)
     else:
         return parse(d)
+
+
+def request_to_curl(request):
+    """
+    Returns a mimic of a request object as a curl. Useful for debugging.
+    curl commands are the CS team's preferred bug reporting method.
+    """
+    command = "curl -v -X{method} -H {headers} -d '{data}' '{uri}'"
+
+    # Redact the authorization token so it doesn't end up in the logs
+    if "Authorization" in request.headers:
+        request.headers["Authorization"] = "Bearer P2P_API_KEY_REDACTED"
+
+    # Format the headers
+    headers = ['"{0}: {1}"'.format(k, v) for k, v in request.headers.items()]
+    headers = " -H ".join(headers)
+
+    # Return the formatted curl command.
+    return command.format(
+        method=request.method,
+        headers=headers,
+        data=request.body,
+        uri=request.url
+    )


### PR DESCRIPTION
Benefits of this PR:
- API keys are now redacted from the logs
- Log messages can easily be shared to the CS team for debugging on their end
- Storing the request information will allow us to better understand exceptions
-  `SECONDS_ELAPSED` records `response.elapsed.total_seconds` in the exception message so we can be aware of the requests that take up a lot of time ([See request docs](http://docs.python-requests.org/en/master/api/#requests.Response.elapsed))

Cons of this PR:
- I've tweaked the format of the exception log, which means any custom exception catching in our apps might break
- ~~Log messages and files are much bigger now, especially since this logs the body and entire payload of each request~~ I just rewrote this a bit so that successful requests don't log curls
