### PR TITLE
P2P.is_token_valid()

### DIFF
--- a/p2p/__init__.py
+++ b/p2p/__init__.py
@@ -1582,7 +1582,6 @@ curl)
         )
 
         # Log the request curl if debug is on
-        print utils.request_to_curl(resp.request)
         if self.debug:
             log.debug("[P2P][HEAD] %s" % utils.request_to_curl(resp.request))
         # If debug is off, store a light weight log

--- a/p2p/tests.py
+++ b/p2p/tests.py
@@ -866,3 +866,16 @@ class CollectionTest(BaseP2PTest):
         self.assertTrue(len(ci_ids) == len(data))
         for k in self.content_item_keys:
             self.assertIn(k, data[0].keys())
+
+class ValidTokenTest(BaseP2PTest):
+
+    def test_that_default_token_is_valid(self):
+        p2p = get_connection()
+        token_is_valid = p2p.is_token_valid()
+        self.assertTrue(token_is_valid, "The test token should be valid")
+
+    def test_that_a_bad_token_is_invalid(self):
+        p2p = get_connection()
+        p2p.config["P2P_API_KEY"] = "MYBADTOKEN"
+        token_is_valid = p2p.is_token_valid()
+        self.assertFalse(token_is_valid, "A bad token should not be valid")


### PR DESCRIPTION
Allows you to make a minimal call to P2P to determine whether or not the current token is valid.

NOTE: This is a part of an upcoming liveblog code change. No need for anyone to review at the moment.