### PR TITLE
Fix core redirect and Throtling

### DIFF
--- a/p2p/__init__.py
+++ b/p2p/__init__.py
@@ -1500,7 +1500,7 @@ curl)
         resp = self.s.get(
             self.config['P2P_API_ROOT'] + url,
             headers=self.http_headers(if_modified_since=if_modified_since),
-            verify=True,
+            verify=True
         )
 
         # Log the request curl if debug is on
@@ -1533,7 +1533,7 @@ curl)
         resp = self.s.delete(
             self.config['P2P_API_ROOT'] + url,
             headers=self.http_headers(),
-            verify=True,)
+            verify=True)
 
         # Log the request curl if debug is on
         if self.debug:
@@ -1552,7 +1552,7 @@ curl)
             self.config['P2P_API_ROOT'] + url,
             data=payload,
             headers=self.http_headers('application/json'),
-            verify=True,
+            verify=True
         )
 
         # Log the request curl if debug is on
@@ -1580,7 +1580,7 @@ curl)
             self.config['P2P_API_ROOT'] + url,
             data=payload,
             headers=self.http_headers('application/json'),
-            verify=True,
+            verify=True
         )
 
         # Log the request curl if debug is on

--- a/p2p/__init__.py
+++ b/p2p/__init__.py
@@ -1414,6 +1414,7 @@ class P2P(object):
         string of the request and a dictionary of response data.
         """
         curl = utils.request_to_curl(resp.request)
+
         request_log = {
             'REQ_URL': req_url,
             'REQ_HEADERS': self.http_headers(),
@@ -1428,6 +1429,13 @@ class P2P(object):
 
         if self.debug:
             log.debug("[P2P][RESPONSE] %s" % request_log)
+
+        if resp.request.url != resp.url:
+            # we got redirected, this probably should not happen on an API request.
+            # throwing a `P2PForbidden` exception would probably be better but
+            # if we throw that a retry would happen and we already know
+            # that we got redirected so something is bad here.
+            raise P2PException(resp.url, request_log, curl)
 
         if resp.status_code >= 500:
             try:
@@ -1485,7 +1493,8 @@ curl)
         resp = self.s.get(
             self.config['P2P_API_ROOT'] + url,
             headers=self.http_headers(if_modified_since=if_modified_since),
-            verify=True
+            verify=True,
+            allow_redirects=False,
         )
 
         # Log the request curl if debug is on
@@ -1518,7 +1527,8 @@ curl)
         resp = self.s.delete(
             self.config['P2P_API_ROOT'] + url,
             headers=self.http_headers(),
-            verify=True)
+            verify=True,
+            allow_redirects=False,)
 
         # Log the request curl if debug is on
         if self.debug:
@@ -1537,7 +1547,8 @@ curl)
             self.config['P2P_API_ROOT'] + url,
             data=payload,
             headers=self.http_headers('application/json'),
-            verify=True
+            verify=True,
+            allow_redirects=False,
         )
 
         # Log the request curl if debug is on
@@ -1565,7 +1576,8 @@ curl)
             self.config['P2P_API_ROOT'] + url,
             data=payload,
             headers=self.http_headers('application/json'),
-            verify=True
+            verify=True,
+            allow_redirects=False,
         )
 
         # Log the request curl if debug is on

--- a/p2p/errors.py
+++ b/p2p/errors.py
@@ -45,6 +45,18 @@ class P2PInvalidFileType(P2PFileError):
 class P2PFileURLNotFound(P2PFileError):
     pass
 
+class P2PRedirectedToLogin(P2PException):
+    """
+    An exception when for some reason the client gets redirected to the login page
+    instead of returning a result.
+    """
+    pass
+
+class P2PThrottled(P2PException):
+    """
+    An exception where the api is being throttled
+    """
+    pass
 
 class P2PRetryableError(P2PException):
     """


### PR DESCRIPTION
When P2P Core redirects an expired ldap token it redirects to an html page that cannot be parsed.
This fixes the issue and also adds 2 new exceptions.

`P2PRedirectedToLogin` is thrown when redirected to the login page
`P2PThrottled` is thrown when content services throws an http 429 due to rate limiting.