### PR TITLE
Python3 compatibility

### DIFF
--- a/.eggs/README.txt
+++ b/.eggs/README.txt
@@ -1,0 +1,6 @@
+This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
+
+This directory caches those eggs to prevent repeated downloads.
+
+However, it is safe to delete this directory.
+

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test ship testcollectionsearch
 
-name='foo'
+name='StoryAndPhotoTest.test_create_or_update_content_item_with_topics'
 
 test:
 	clear

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test:
 		coverage report -m;\
 	else \
 		echo "Running provided test";\
-		python -m unittest p2p.tests.TestP2P.$(name);\
+		python -m unittest p2p.tests.$(name);\
 	fi
 
 ship:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test ship testcollectionsearch
 
-name='StoryAndPhotoTest.test_create_or_update_content_item_with_topics'
+name='foo'
 
 test:
 	clear

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,22 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+pep8 = "*"
+pyflakes = "*"
+coverage = "*"
+python-coveralls = "*"
+iso8601 = "*"
+python-dateutil = "*"
+pytz = "*"
+requests = "*"
+six = "*"
+twine = "*"
+future = "*"
+
+[requires]
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,225 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "265b11e3aa36115801fa8b0deb23e684fb50b254c56aa63c3f14ddd053457715"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "bleach": {
+            "hashes": [
+                "sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16",
+                "sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa"
+            ],
+            "version": "==3.1.0"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
+                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+            ],
+            "version": "==2018.11.29"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:00d464797a236f654337181af72b4baea3d35d056ca480e45e9163bb5df496b8",
+                "sha256:0a90afa6f5ea08889da9066dca3ce2ef85d47587e3f66ca06a4fa8d3a0053acc",
+                "sha256:50727512afe77e044c7d7f2fd4cd0fe62b06527f965b335a810d956748e0514d",
+                "sha256:6c2fd127cd4e2decb0ab41fe3ac2948b87ad2ea0470e24b4be5f7e7fdfef8df3",
+                "sha256:6ed521ed3800d8f8911642b9b3c3891780a929db5e572c88c4713c1032530f82",
+                "sha256:76a73a48a308fb87a4417d630b0345d36166f489ef17ea5aa8e4596fb50a2296",
+                "sha256:85b1275b6d7a61ccc8024a4e9a4c9e896394776edce1a5d075ec116f91925462",
+                "sha256:8e60e720cad3ee6b0a32f475ae4040552c5623870a9ca0d3d4263faa89a8d96b",
+                "sha256:93c50475f189cd226e9688b9897a0cd3c4c5d9c90b1733fa8f6445cfc0182c51",
+                "sha256:94c1e66610807a7917d967ed6415b9d5fde7487ab2a07bb5e054567865ef6ef0",
+                "sha256:964f86394cb4d0fd2bb40ffcddca321acf4323b48d1aa5a93db8b743c8a00f79",
+                "sha256:99043494b28d6460035dd9410269cdb437ee460edc7f96f07ab45c57ba95e651",
+                "sha256:af2f59ce312523c384a7826821cae0b95f320fee1751387abba4f00eed737166",
+                "sha256:beb96d32ce8cfa47ec6433d95a33e4afaa97c19ac1b4a47ea40a424fedfee7c2",
+                "sha256:c00bac0f6b35b82ace069a6a0d88e8fd4cd18d964fc5e47329cd02b212397fbe",
+                "sha256:d079e36baceea9707fd50b268305654151011274494a33c608c075808920eda8",
+                "sha256:e813cba9ff0e3d37ad31dc127fac85d23f9a26d0461ef8042ac4539b2045e781"
+            ],
+            "index": "pypi",
+            "version": "==4.0.3"
+        },
+        "docutils": {
+            "hashes": [
+                "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
+                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274",
+                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
+            ],
+            "version": "==0.14"
+        },
+        "future": {
+            "hashes": [
+                "sha256:67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8"
+            ],
+            "index": "pypi",
+            "version": "==0.17.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
+        "iso8601": {
+            "hashes": [
+                "sha256:210e0134677cc0d02f6028087fee1df1e1d76d372ee1db0bf30bf66c5c1c89a3",
+                "sha256:49c4b20e1f38aa5cf109ddcd39647ac419f928512c869dc01d5c7098eddede82",
+                "sha256:bbbae5fb4a7abfe71d4688fd64bff70b91bbd74ef6a99d964bab18f7fdf286dd"
+            ],
+            "index": "pypi",
+            "version": "==0.1.12"
+        },
+        "pep8": {
+            "hashes": [
+                "sha256:b22cfae5db09833bb9bd7c8463b53e1a9c9b39f12e304a8d0bba729c501827ee",
+                "sha256:fe249b52e20498e59e0b5c5256aa52ee99fc295b26ec9eaa85776ffdb9fe6374"
+            ],
+            "index": "pypi",
+            "version": "==1.7.1"
+        },
+        "pkginfo": {
+            "hashes": [
+                "sha256:7424f2c8511c186cd5424bbf31045b77435b37a8d604990b79d4e70d741148bb",
+                "sha256:a6d9e40ca61ad3ebd0b72fbadd4fba16e4c0e4df0428c041e01e06eb6ee71f32"
+            ],
+            "version": "==1.5.0.1"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
+                "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
+            ],
+            "index": "pypi",
+            "version": "==2.1.1"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:5ffada19f6203563680669ee7f53b64dabbeb100eb51b61996085e99c03b284a",
+                "sha256:e8218dd399a61674745138520d0d4cf2621d7e032439341bc3f647bff125818d"
+            ],
+            "version": "==2.3.1"
+        },
+        "python-coveralls": {
+            "hashes": [
+                "sha256:1748272081e0fc21e2c20c12e5bd18cb13272db1b130758df0d473da0cb31087",
+                "sha256:736dda01f64beda240e1500d5f264b969495b05fcb325c7c0eb7ebbfd1210b70"
+            ],
+            "index": "pypi",
+            "version": "==2.9.1"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+            ],
+            "index": "pypi",
+            "version": "==2.8.0"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
+                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
+            ],
+            "index": "pypi",
+            "version": "==2018.9"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
+                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
+                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
+                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
+                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
+                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
+                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
+                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
+                "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
+                "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
+                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
+            ],
+            "version": "==3.13"
+        },
+        "readme-renderer": {
+            "hashes": [
+                "sha256:bb16f55b259f27f75f640acf5e00cf897845a8b3e4731b5c1a436e4b8529202f",
+                "sha256:c8532b79afc0375a85f10433eca157d6b50f7d6990f337fa498c96cd4bfc203d"
+            ],
+            "version": "==24.0"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
+                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+            ],
+            "index": "pypi",
+            "version": "==2.21.0"
+        },
+        "requests-toolbelt": {
+            "hashes": [
+                "sha256:380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f",
+                "sha256:968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0"
+            ],
+            "version": "==0.9.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "index": "pypi",
+            "version": "==1.12.0"
+        },
+        "tqdm": {
+            "hashes": [
+                "sha256:d385c95361699e5cf7622485d9b9eae2d4864b21cd5a2374a9c381ffed701021",
+                "sha256:e22977e3ebe961f72362f6ddfb9197cc531c9737aaf5f607ef09740c849ecd05"
+            ],
+            "version": "==4.31.1"
+        },
+        "twine": {
+            "hashes": [
+                "sha256:0fb0bfa3df4f62076cab5def36b1a71a2e4acb4d1fa5c97475b048117b1a6446",
+                "sha256:d6c29c933ecfc74e9b1d9fa13aa1f87c5d5770e119f5a4ce032092f0ff5b14dc"
+            ],
+            "index": "pypi",
+            "version": "==1.13.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
+                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+            ],
+            "version": "==1.24.1"
+        },
+        "webencodings": {
+            "hashes": [
+                "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
+                "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
+            ],
+            "version": "==0.5.1"
+        }
+    },
+    "develop": {}
+}

--- a/p2p/__init__.py
+++ b/p2p/__init__.py
@@ -1500,8 +1500,16 @@ curl)
         return request_log
 
     def convert_response_bytes_to_string(self, response):
-        if str(type(response.content)) == "<class 'bytes'>":
-            return response.content.decode("utf-8") 
+        vartype = str(type(response.content))
+        if vartype == "<class 'bytes'>":
+            # Convert to str
+            return response.content.decode("utf-8")
+        elif vartype == "<class 'str'>":
+            # It's already a str, just return it
+            return response.content
+
+        # It is not a string type, return empty
+        return ''
 
     @retry(P2PRetryableError)
     def get(self, url, query=None, if_modified_since=None):

--- a/p2p/auth.py
+++ b/p2p/auth.py
@@ -1,3 +1,4 @@
+from builtins import object
 import requests
 import json
 from .adapters import TribAdapter
@@ -48,7 +49,7 @@ def authenticate(username=None, password=None, token=None, auth_url=None):
 try:
     from django.contrib.auth.models import User
 
-    class P2PBackend:
+    class P2PBackend(object):
         def authenticate(self, username=None, password=None):
 
             try:
@@ -85,7 +86,7 @@ try:
             except User.DoesNotExist:
                 return None
 
-except ImportError, e:
+except ImportError as e:
     pass
 
 

--- a/p2p/cache.py
+++ b/p2p/cache.py
@@ -1,6 +1,8 @@
 # (almost) pure python
+from builtins import str
+from builtins import object
 from copy import deepcopy
-import utils
+from p2p import utils
 
 
 class BaseCache(object):
@@ -265,7 +267,7 @@ class DictionaryCache(BaseCache):
             return self.log[type].copy() if type in self.log else None
         else:
             keyname = self.make_key(type, id)
-            return self.log[keyname].values() if keyname in self.log else None
+            return list(self.log[keyname].values()) if keyname in self.log else None
 
     def log_remove(self, type, id, query):
         if type in self.log:
@@ -345,7 +347,7 @@ try:
         def log_key(self, type, id, query):
             pass
 
-except ImportError, e:
+except ImportError:
     pass
 
 try:
@@ -526,5 +528,5 @@ try:
         def clear(self):
             self.r.flushdb()
 
-except ImportError, e:
+except ImportError:
     pass

--- a/p2p/filters.py
+++ b/p2p/filters.py
@@ -1,4 +1,20 @@
+from builtins import str
 import re
+
+try:
+    unicode = unicode
+except NameError:
+    # 'unicode' is undefined, must be Python 3
+    str = str
+    unicode = str
+    bytes = bytes
+    basestring = (str,bytes)
+else:
+    # 'unicode' exists, must be Python 2
+    str = str
+    unicode = unicode
+    bytes = str
+    basestring = basestring
 
 UNQUERYABLE_PATTERN = re.compile('\.[a-zA-Z]+$')
 QUERY_PATTERN = re.compile('/\d+(/\d+x\d+)?$')
@@ -237,10 +253,10 @@ def force_unicode(s, encoding='utf-8', errors='ignore'):
     try:
         if not isinstance(s, basestring,):
             if hasattr(s, '__unicode__'):
-                s = unicode(s)
+                s = str(s)
             else:
                 try:
-                    s = unicode(str(s), encoding, errors)
+                    s = str(str(s), encoding, errors)
                 except UnicodeEncodeError:
                     if not isinstance(s, Exception):
                         raise
@@ -252,12 +268,12 @@ def force_unicode(s, encoding='utf-8', errors='ignore'):
                     # output should be.
                     s = ' '.join(
                         [force_unicode(arg, encoding, errors) for arg in s])
-        elif not isinstance(s, unicode):
+        elif not isinstance(s, str):
             # Note: We use .decode() here, instead of unicode(s, encoding,
             # errors), so that if s is a SafeString, it ends up being a
             # SafeUnicode at the end.
             s = s.decode(encoding, errors)
-    except UnicodeDecodeError, e:
+    except UnicodeDecodeError as e:
         if not isinstance(s, Exception):
             raise UnicodeDecodeError(s, *e.args)
         else:

--- a/p2p/tests.py
+++ b/p2p/tests.py
@@ -57,13 +57,13 @@ class BaseP2PTest(unittest.TestCase):
         # Make sure everything is cleared out first
         for slug in cls.test_story_slugs:
             try:
-                cls.p2p.delete_collection(slug)
+                cls.p2p.delete_content_item(slug)
             except P2PNotFound:
                 pass
 
         # Create a bunch of test stories and store to self.test_story_slugs
         for slug in cls.test_story_slugs:
-            cls.p2p.create_or_update_content_item({
+            cls.p2p.create_content_item({
                 "slug": slug,
                 "content_item_type_code": "story",
                 "title": "Temporary content item #%s for unittesting" % slug,
@@ -147,11 +147,11 @@ class StoryAndPhotoTest(BaseP2PTest):
             "title": "Test HTML story"
         })
 
-    def test_create_or_update_content_item_with_topics(self):
-        topics = ["PEBSL000163", "PEPLT007433"]
+    def test_update_content_item_with_topics(self):
+        topics = [u'PEBSL000163', "PEPLT007433"]
 
         # Add topics to the story
-        self.p2p.create_or_update_content_item({
+        self.p2p.update_content_item({
             "add_topic_ids": topics,
             "content_item": {
                 "slug": self.first_test_story_slug,
@@ -164,11 +164,12 @@ class StoryAndPhotoTest(BaseP2PTest):
 
         # Make sure the topics were added correctly
         data = self.p2p.get_fancy_content_item(self.first_test_story_slug, query=query)
+
         content_topics = data["content_topics"]
         self.assertEqual(len(content_topics), 2)
 
         # Now let's remove the topics
-        self.p2p.create_or_update_content_item({
+        self.p2p.update_content_item({
             "remove_topic_ids": topics,
             "content_item": {
                 "slug": self.first_test_story_slug,

--- a/p2p/tests.py
+++ b/p2p/tests.py
@@ -161,6 +161,10 @@ class StoryAndPhotoTest(BaseP2PTest):
             },
         })
 
+        # Add content_topics to our content item query
+        query = self.p2p.default_content_item_query
+        query["include"].append("content_topics")
+
         # Make sure the topics were added correctly
         data = self.p2p.get_fancy_content_item(self.first_test_story_slug, query=query)
         self.assertEqual(

--- a/p2p/tests.py
+++ b/p2p/tests.py
@@ -1,3 +1,4 @@
+from builtins import range
 import pprint
 import unittest
 from p2p import (
@@ -156,11 +157,11 @@ class StoryAndPhotoTest(BaseP2PTest):
         # Story
         data = self.p2p.get_content_item(self.first_test_story_slug)
         for k in self.content_item_keys:
-            self.assertIn(k, data.keys())
+            self.assertIn(k, list(data.keys()))
         # HTML story
         data = self.p2p.get_content_item(self.test_htmlstory_slug)
         for k in self.content_item_keys:
-            self.assertIn(k, data.keys())
+            self.assertIn(k, list(data.keys()))
 
     def test_related_items(self):
         # Add
@@ -337,7 +338,7 @@ class StoryAndPhotoTest(BaseP2PTest):
 
         self.assertIn(
             'html_story',
-            result.keys()
+            list(result.keys())
         )
         res = result['html_story']
         self.assertEqual(res['slug'], data['slug'])
@@ -368,7 +369,7 @@ class StoryAndPhotoTest(BaseP2PTest):
 
         self.assertIn(
             'html_story',
-            result.keys()
+            list(result.keys())
         )
         res = result['html_story']
         self.assertEqual(res['slug'], data['slug'])
@@ -430,7 +431,7 @@ class StoryAndPhotoTest(BaseP2PTest):
 
         # Ensure the first item has all the keys we expect
         for k in self.content_item_keys:
-            self.assertIn(k, data[0].keys())
+            self.assertIn(k, list(data[0].keys()))
 
         # Loop through each content item and ensure the ID
         # matches what was passed in to get_multi_content_items
@@ -766,16 +767,16 @@ class CollectionTest(BaseP2PTest):
     def test_get_collection(self):
         data = self.p2p.get_collection(self.first_test_collection_code)
         for k in self.collection_keys:
-            self.assertIn(k, data.keys())
+            self.assertIn(k, list(data.keys()))
 
     def test_get_collection_layout(self):
         data = self.p2p.get_collection_layout(self.first_test_collection_code)
 
         for k in self.content_layout_keys:
-            self.assertIn(k, data.keys())
+            self.assertIn(k, list(data.keys()))
 
         for k in self.content_layout_item_keys:
-            self.assertIn(k, data['items'][0].keys())
+            self.assertIn(k, list(data['items'][0].keys()))
 
     def test_fancy_collection(self):
         data = self.p2p.get_fancy_collection(
@@ -784,15 +785,15 @@ class CollectionTest(BaseP2PTest):
         )
 
         for k in self.content_layout_keys:
-            self.assertIn(k, data.keys())
+            self.assertIn(k, list(data.keys()))
 
         for k in self.collection_keys:
-            self.assertIn(k, data['collection'].keys())
+            self.assertIn(k, list(data['collection'].keys()))
 
         self.assertTrue(len(data['items']) > 0)
 
         for k in self.content_layout_item_keys:
-            self.assertIn(k, data['items'][0].keys())
+            self.assertIn(k, list(data['items'][0].keys()))
 
     def test_that_unique_contraint_exception_is_raised(self):
         """
@@ -891,7 +892,7 @@ class CollectionTest(BaseP2PTest):
         data = self.p2p.get_multi_content_items(ci_ids)
         self.assertTrue(len(ci_ids) == len(data))
         for k in self.content_item_keys:
-            self.assertIn(k, data[0].keys())
+            self.assertIn(k, list(data[0].keys()))
 
     def test_that_converting_to_array_works(self):
         """

--- a/p2p/utils.py
+++ b/p2p/utils.py
@@ -36,7 +36,7 @@ def dict_to_qs(dictionary):
 
     for k, v in list(dictionary.items()):
         if isinstance(v, dict):
-            for k2, v2 in list(v.items()):
+            for k2, v2 in v.items():
                 if type(v2) in (str, str, int, float, bool):
                     qs.append("%s[%s]=%s" % (k, k2, v2))
                 elif type(v2) in (list, tuple):
@@ -75,7 +75,7 @@ def parse_response(resp):
             return parsedate(resp)
     elif type(resp) is dict:
         # would use list comprehension, but that makes unnecessary copies
-        for k, v in list(resp.items()):
+        for k, v in resp.items():
             resp[k] = parse_response(v)
     elif type(resp) is list:
         # would use list comprehension, but that makes unnecessary copies
@@ -94,7 +94,7 @@ def parse_request(data):
         return formatdate(data)
     elif type(data) is dict:
         # would use list comprehension, but that makes unnecessary copies
-        for k, v in list(data.items()):
+        for k, v in data.items():
             data[k] = parse_request(v)
     elif type(data) is list:
         # would use list comprehension, but that makes unnecessary copies
@@ -130,7 +130,7 @@ def request_to_curl(request):
         request.headers["Authorization"] = "Bearer P2P_API_KEY_REDACTED"
 
     # Format the headers
-    headers = ['"{0}: {1}"'.format(k, v) for k, v in list(request.headers.items())]
+    headers = ['"{0}: {1}"'.format(k, v) for k, v in request.headers.items()]
     headers = " -H ".join(headers)
 
     # Return the formatted curl command.

--- a/p2p/utils.py
+++ b/p2p/utils.py
@@ -1,3 +1,5 @@
+from builtins import str
+from builtins import range
 import iso8601
 import re
 import pytz
@@ -18,10 +20,10 @@ def slugify(value):
     From Django's "django/template/defaultfilters.py".
     """
     import unicodedata
-    if not isinstance(value, unicode):
-        value = unicode(value)
+    if not isinstance(value, str):
+        value = str(value)
     value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore')
-    value = unicode(_slugify_strip_re.sub('', value).strip().lower())
+    value = str(_slugify_strip_re.sub('', value).strip().lower())
     return _slugify_hyphenate_re.sub('-', value)
 
 
@@ -32,20 +34,20 @@ def dict_to_qs(dictionary):
     """
     qs = list()
 
-    for k, v in dictionary.items():
+    for k, v in list(dictionary.items()):
         if isinstance(v, dict):
-            for k2, v2 in v.items():
-                if type(v2) in (str, unicode, int, float, bool):
+            for k2, v2 in list(v.items()):
+                if type(v2) in (str, str, int, float, bool):
                     qs.append("%s[%s]=%s" % (k, k2, v2))
                 elif type(v2) in (list, tuple):
                     for v3 in v2:
                         qs.append("%s[%s][]=%s" % (k, k2, v3))
                 elif type(v2) == dict:
-                    for k3, v3 in v2.items():
+                    for k3, v3 in list(v2.items()):
                         qs.append("%s[%s][%s]=%s" % (k, k2, k3, v3))
                 else:
                     raise TypeError
-        elif type(v) in (str, unicode, int, float, bool):
+        elif type(v) in (str, str, int, float, bool):
             qs.append("%s=%s" % (k, v))
         elif type(v) in (list, tuple):
             for v2 in v:
@@ -61,7 +63,7 @@ def parse_response(resp):
     Recurse through a dictionary from an API call, and fix weird values,
     convert date strings to objects, etc.
     """
-    if type(resp) in (str, unicode):
+    if type(resp) in (str, str):
         if resp in ("null", "Null"):
             # Null value as a string
             return None
@@ -73,7 +75,7 @@ def parse_response(resp):
             return parsedate(resp)
     elif type(resp) is dict:
         # would use list comprehension, but that makes unnecessary copies
-        for k, v in resp.items():
+        for k, v in list(resp.items()):
             resp[k] = parse_response(v)
     elif type(resp) is list:
         # would use list comprehension, but that makes unnecessary copies
@@ -92,7 +94,7 @@ def parse_request(data):
         return formatdate(data)
     elif type(data) is dict:
         # would use list comprehension, but that makes unnecessary copies
-        for k, v in data.items():
+        for k, v in list(data.items()):
             data[k] = parse_request(v)
     elif type(data) is list:
         # would use list comprehension, but that makes unnecessary copies
@@ -128,7 +130,7 @@ def request_to_curl(request):
         request.headers["Authorization"] = "Bearer P2P_API_KEY_REDACTED"
 
     # Format the headers
-    headers = ['"{0}: {1}"'.format(k, v) for k, v in request.headers.items()]
+    headers = ['"{0}: {1}"'.format(k, v) for k, v in list(request.headers.items())]
     headers = " -H ".join(headers)
 
     # Return the formatted curl command.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ coverage
 python-coveralls
 # Requirements
 iso8601
+future
 python-dateutil
 pytz
 requests

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     packages=find_packages(),
     install_requires=(
         "python-dateutil",
+        "future",
         "requests",
         "iso8601",
         "pytz",


### PR DESCRIPTION
Changes include:

- Polyfilling builtin libs
- More explicit `import syntax`
- Converting `bytes` to strings for parsing
- Explicitly casting `dict.keys()` iterables to lists
- Updated exception handling syntax
- Only log request cUrls if `self.debug` is `True`